### PR TITLE
Ajustando la lista de modulos por categoria

### DIFF
--- a/categoria/models.py
+++ b/categoria/models.py
@@ -6,7 +6,7 @@ class Categoria(models.Model):
     estado = models.BooleanField(default=True)
     
     def __str__(self):
-        return f'{self.id_categoria} - {self.nombre} - {self.descripcion}'
+        return f'{self.id_categoria} - {self.nombre} - {"Activo" if self.estado else "Inactivo"}'
     class Meta:
         verbose_name = 'Categoria'
         verbose_name_plural = 'Categorias'


### PR DESCRIPTION
Este pull request introduce dos cambios clave: una mejora en la representación de cadenas del modelo `Categoria` y una reestructuración significativa del método `listar_por_categoria` para mejorar la forma en que los módulos se agrupan y devuelven por categoría. Estos cambios pretenden mejorar la claridad y funcionalidad del código.

### Cambios en el modelo `Categoria`:
* Actualizado el método `__str__` en `categoria/models.py` para incluir el campo `estado` en un formato legible por humanos («Activo» o «Inactivo») en lugar de mostrar la descripción. Esto hace que la representación de la cadena sea más concisa e informativa.

### Cambios en el método `listar_por_categoria`:
* Refactorizado el método `listar_por_categoria` en `modulo/views.py` para:
  - Usar IDs numéricos de categoría (`id_categoria`) como claves en lugar de nombres de categoría para agrupar, asegurando la consistencia y evitando problemas potenciales con nombres duplicados.
  - Introducir un diccionario `categorias_info` para almacenar metadatos para cada categoría, mejorando la separación de preocupaciones y simplificando la construcción final de la respuesta.
  - Modificar el formato de la respuesta para incluir las propiedades de las categorías (`id` y `nombre`) junto con sus módulos asociados, mejorando la usabilidad y claridad de la API.

Traducción realizada con la versión gratuita del traductor DeepL.com