### PR TITLE
obtener_oferta_categoria_por_oferta_academica ingresar sin autenticac…

### DIFF
--- a/oferta_categoria/views.py
+++ b/oferta_categoria/views.py
@@ -11,7 +11,7 @@ from .models import OfertaCategoria
 # Serializadores
 from .serializers import OfertaCategoriaReadSerializer, OfertaCategoriaWriteSerializer
 # Autenticación
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 # Permisos
 from cuenta.permissions import IsEstudiante, IsProfesor, IsAdministrador, IsProfesorOrAdministrador
 
@@ -41,7 +41,10 @@ class OfertaCategoriaViewSet(viewsets.ModelViewSet):
         - Solo los administradores pueden realizar cualquier operación
         - Estudiantes y profesores no tienen acceso
         """
-        permission_classes = [IsAuthenticated, IsAdministrador]
+        if self.action == 'obtener_oferta_categoria_por_oferta_academica':
+            permission_classes = [AllowAny] 
+        else:
+            permission_classes = [IsAuthenticated, IsAdministrador]
         return [permission() for permission in permission_classes]
     
     @swagger_auto_schema(


### PR DESCRIPTION
Esta solicitud de extracción actualiza la lógica de permisos en el archivo `oferta_categoria/views.py` para permitir el acceso no autenticado a la acción `obtener_oferta_categoria_por_oferta_academica`, manteniendo permisos estrictos para otras acciones. Los cambios garantizan que este punto final específico sea de acceso público, lo cual puede ser útil en escenarios donde la información de la categoría debe estar disponible sin autenticación.

Actualizaciones de la lógica de permisos:

* Se importó `AllowAny` de `rest_framework.permissions` para habilitar el acceso no autenticado para acciones específicas.
* Se modificó el método `get_permissions` para usar `AllowAny` para la acción `obtener_oferta_categoria_por_oferta_academica`, manteniendo `[IsAuthenticated, IsAdministrador]` para todas las demás acciones.